### PR TITLE
fix: correct storage env var names and server-side API URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,12 +19,12 @@ DATABASE_MIGRATOR_URL=postgresql://migrator:changeme@db:5432/photo
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=changeme
 
-# Application credentials — scoped to the photo bucket
-MINIO_ENDPOINT=minio:9000
-MINIO_ACCESS_KEY=changeme
-MINIO_SECRET_KEY=changeme
-MINIO_BUCKET_NAME=photos
-MINIO_USE_SSL=false
+# Application credentials — must match MINIO_ROOT_USER / MINIO_ROOT_PASSWORD above
+STORAGE_ENDPOINT=minio:9000
+STORAGE_ACCESS_KEY=minioadmin
+STORAGE_SECRET_KEY=changeme
+STORAGE_BUCKET=photos
+STORAGE_USE_SSL=false
 
 # ── Redis ───────────────────────────────────────────────────────────────────
 REDIS_URL=redis://redis:6379/0
@@ -45,5 +45,7 @@ MAX_UPLOAD_SIZE_BYTES=5368709120
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost
 
 # ── Frontend ────────────────────────────────────────────────────────────────
-# URL reachable from the browser (goes through Caddy)
+# Server-side URL (used by Next.js server components inside Docker)
+API_URL=http://backend:8000
+# Browser-facing URL (goes through Caddy)
 NEXT_PUBLIC_API_URL=http://localhost/api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
     restart: unless-stopped
     env_file: .env
     environment:
+      API_URL: http://backend:8000
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
     volumes:
       - ./frontend:/app

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,7 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+// API_URL is used by server components (internal Docker network).
+// NEXT_PUBLIC_API_URL is used by the browser (goes through Caddy).
+const API_BASE_URL =
+  process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 export async function checkHealth(): Promise<boolean> {
   try {


### PR DESCRIPTION
Two bugs found during first `docker compose up`:

**1. Wrong env var names for storage credentials**
`config.py` reads `STORAGE_ACCESS_KEY` / `STORAGE_SECRET_KEY` but `.env.example` had `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` — backend fell back to `changeme` instead of `minioadmin`, causing a 403 on startup.

**2. Server-side vs browser API URL**
`NEXT_PUBLIC_API_URL=http://localhost/api` resolves correctly in the browser (through Caddy) but not inside the frontend Docker container. Added `API_URL=http://backend:8000` to the frontend service for server component use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)