### PR TITLE
fix: pin pyasn1>=0.6.3 to resolve CVE-2026-30922

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ psycopg[binary]==3.3.3
 geoalchemy2==0.17.0
 boto3==1.35.99
 python-jose[cryptography]==3.5.0
+pyasn1>=0.6.3  # CVE-2026-30922: fix transitive vuln via python-jose/boto3
 bcrypt==4.2.1
 slowapi==0.1.9
 email-validator==2.2.0


### PR DESCRIPTION
## Summary

Pins `pyasn1>=0.6.3` directly in `requirements.txt` to force the patched version.

`pyasn1 0.4.8` (CVE-2026-30922, fixed in 0.6.3) was being pulled in transitively via `python-jose[cryptography]` and `boto3`. This was causing the Python dependency audit to fail on every open PR.

## Test plan
- [ ] Python dependency audit passes (no more CVE-2026-30922)

🤖 Generated with [Claude Code](https://claude.com/claude-code)