### PR TITLE
chore: upgrade bcrypt 5, python-json-logger 4, pydantic-settings 2.13

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -21,6 +21,17 @@ from app.models.user import User
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
+_BCRYPT_MAX_BYTES = 72  # bcrypt silently truncated >72 bytes in v4; v5 raises ValueError
+
+
+def _check_password_length(password: str) -> None:
+    if len(password.encode()) > _BCRYPT_MAX_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Password must not exceed {_BCRYPT_MAX_BYTES} bytes.",
+        )
+
+
 def _hash_password(password: str) -> str:
     return _bcrypt.hashpw(password.encode(), _bcrypt.gensalt()).decode()
 
@@ -170,6 +181,8 @@ async def register(
                 detail="Email does not match invitation.",
             )
 
+    _check_password_length(body.password)
+
     existing = await session.scalar(select(User).where(User.email == body.email))
     if existing:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email already registered.")
@@ -207,6 +220,8 @@ async def login(
     session: AsyncSession = Depends(get_session),
 ) -> TokenResponse:
     ip = _client_ip(request)
+
+    _check_password_length(body.password)
 
     user = await session.scalar(select(User).where(User.email == body.email))
 

--- a/backend/app/api/shares.py
+++ b/backend/app/api/shares.py
@@ -37,6 +37,17 @@ def _hash_token(raw: str) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
+_BCRYPT_MAX_BYTES = 72
+
+
+def _check_password_length(password: str) -> None:
+    if len(password.encode()) > _BCRYPT_MAX_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Password must not exceed {_BCRYPT_MAX_BYTES} bytes.",
+        )
+
+
 def _hash_password(password: str) -> str:
     return _bcrypt.hashpw(password.encode(), _bcrypt.gensalt()).decode()
 
@@ -119,6 +130,8 @@ async def create_share(
     The token is returned once — it is not stored and cannot be recovered.
     """
     raw_token = secrets.token_urlsafe(32)
+    if body.password:
+        _check_password_length(body.password)
     pw_hash = _hash_password(body.password) if body.password else None
 
     share = Share(

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from contextvars import ContextVar
 
-from pythonjsonlogger.jsonlogger import JsonFormatter
+from pythonjsonlogger.json import JsonFormatter
 
 # Stores the current request ID for the duration of a single request.
 # Set by RequestIdMiddleware; read by RequestIdFilter.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.135.2
 uvicorn[standard]==0.32.1
-pydantic-settings==2.7.1
-python-json-logger==2.0.7
+pydantic-settings==2.13.1
+python-json-logger==4.0.0
 sqlalchemy[asyncio]==2.0.48
 alembic==1.14.0
 asyncpg==0.30.0
@@ -10,7 +10,7 @@ geoalchemy2==0.17.0
 boto3==1.35.99
 python-jose[cryptography]==3.5.0
 pyasn1>=0.6.3  # CVE-2026-30922: fix transitive vuln via python-jose/boto3
-bcrypt==4.2.1
+bcrypt==5.0.0
 slowapi==0.1.9
 email-validator==2.3.0
 filetype==1.2.0


### PR DESCRIPTION
Supersedes #58, #59, #61.

## Changes

**bcrypt 4.2.1 → 5.0.0**
- Breaking: `hashpw` now raises `ValueError` for passwords >72 bytes (previously silently truncated)
- Added `_check_password_length` guard called before any `hashpw`/`checkpw` in `auth.py` (register, login) and `shares.py` (create share with password)

**python-json-logger 2.0.7 → 4.0.0**
- Breaking: import path moved from `pythonjsonlogger.jsonlogger` to `pythonjsonlogger.json`
- Updated `app/core/logging.py`

**pydantic-settings 2.7.1 → 2.13.1**
- Minor version bump, no code changes needed

## Test plan
- [ ] CI passes (Python dependency audit + existing test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)