### PR TITLE
fix(auth): refresh token cookie path broken through Caddy proxy

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -289,7 +289,7 @@ async def login(
         secure=settings.cookie_secure,
         samesite="strict",
         max_age=settings.refresh_token_expire_days * 86400,
-        path="/auth/refresh",
+        path="/",
     )
 
     return TokenResponse(access_token=create_access_token(str(user.id)))
@@ -346,7 +346,7 @@ async def refresh(
         secure=settings.cookie_secure,
         samesite="strict",
         max_age=settings.refresh_token_expire_days * 86400,
-        path="/auth/refresh",
+        path="/",
     )
 
     return TokenResponse(access_token=create_access_token(str(record.user_id)))


### PR DESCRIPTION
## Summary
- The refresh token cookie was scoped to `path="/auth/refresh"` but the browser-facing URL through Caddy is `/api/auth/refresh` — the browser never sent the cookie, so every page refresh required a new login
- Fix: widen cookie path to `/`; still fully protected by `HttpOnly` + `SameSite=Strict`

## Test plan
- [ ] Log in, navigate to `/import`, refresh the page — should stay logged in without redirecting to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)