### PR TITLE
fix(upload): handle large folder uploads without crashing

### DIFF
--- a/backend/app/api/upload.py
+++ b/backend/app/api/upload.py
@@ -22,14 +22,13 @@ POST /upload
 
 from __future__ import annotations
 
-import io
 import uuid
-from typing import Annotated
 
 import filetype as _filetype
 from botocore.exceptions import ClientError
-from fastapi import APIRouter, Depends, Form, UploadFile, status
+from fastapi import APIRouter, Depends, Request, UploadFile, status
 from fastapi.responses import JSONResponse
+from starlette.datastructures import UploadFile as StarletteUploadFile
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -83,8 +82,7 @@ def _detect_mime(data: bytes) -> str | None:
     response_model=StartUploadResponse,
 )
 async def start_direct_upload(
-    files: list[UploadFile],
-    paths: Annotated[list[str] | None, Form()] = None,
+    request: Request,
     album_id: uuid.UUID | None = None,
     user_id: uuid.UUID = Depends(get_current_user),
     session: AsyncSession = Depends(get_authed_session),
@@ -95,6 +93,23 @@ async def start_direct_upload(
     asynchronously by a Celery worker.  Poll
     ``GET /import/jobs/{job_id}`` to track progress.
     """
+    # Parse multipart with raised limits. FastAPI constructor kwargs
+    # (multipart_max_files) are stored in app.extra but not applied by starlette,
+    # so we configure limits here where they actually take effect.
+    form = await request.form(
+        max_files=50_000,
+        max_fields=100_000,
+        max_part_size=settings.max_upload_size_bytes,  # starlette 1.0 added 1 MB default cap
+    )
+    # request.form() returns starlette UploadFile instances, not FastAPI's subclass,
+    # so check against the starlette base class.
+    files: list[UploadFile] = [
+        v for _, v in form.multi_items() if isinstance(v, StarletteUploadFile)
+    ]
+    paths: list[str] = [
+        v for k, v in form.multi_items() if k == "paths" and isinstance(v, str)
+    ]
+
     if not files:
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -112,24 +127,17 @@ async def start_direct_upload(
 
     for index, (upload, rel_path) in enumerate(zip(files, resolved_paths)):
         filename = upload.filename or f"file_{index}"
-        data = await upload.read()
 
-        # Per-file size guard
-        if len(data) > settings.max_upload_size_bytes:
-            pre_errors.append(
-                {
-                    "filename": filename,
-                    "reason": (
-                        f"Exceeds the maximum allowed size of "
-                        f"{settings.max_upload_size_bytes // (1024 * 1024)} MB."
-                    ),
-                }
-            )
-            continue
+        # request.form() leaves the file pointer at EOF after parsing; reset first.
+        await upload.seek(0)
+
+        # Read only the first 512 bytes for MIME detection — avoids loading the
+        # entire file into RAM (large videos can be several GB).
+        header = await upload.read(512)
 
         # MIME detection via magic bytes (not declared Content-Type — browsers
         # mis-report HEIC and other formats)
-        mime = _detect_mime(data)
+        mime = _detect_mime(header)
         if mime is None:
             pre_errors.append(
                 {
@@ -142,14 +150,34 @@ async def start_direct_upload(
             )
             continue
 
+        # Measure file size without buffering the whole file.
+        # upload.file is a SpooledTemporaryFile (sync); seek/tell work fine here.
+        upload.file.seek(0, 2)
+        file_size = upload.file.tell()
+        upload.file.seek(0)
+
+        # Per-file size guard
+        if file_size > settings.max_upload_size_bytes:
+            pre_errors.append(
+                {
+                    "filename": filename,
+                    "reason": (
+                        f"Exceeds the maximum allowed size of "
+                        f"{settings.max_upload_size_bytes // (1024 * 1024)} MB."
+                    ),
+                }
+            )
+            continue
+
         suffix = _SUFFIX_MAP.get(mime, "")
         key = _STAGING_KEY_TMPL.format(
             user_id=user_id, job_id=job_id, index=index, suffix=suffix
         )
 
         try:
+            # Stream directly from the spooled temp file to S3 — no full-RAM copy.
             storage_service._client.upload_fileobj(
-                io.BytesIO(data),
+                upload.file,
                 storage_service._bucket,
                 key,
                 ExtraArgs={"ContentType": mime},

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -20,6 +20,33 @@ import {
   type ImportJobStatus,
 } from "@/lib/api";
 
+const BATCH_SIZE = 200; // max files per POST request
+
+// Fingerprint a file by its relative path + size — good enough to skip re-uploads on retry.
+function fingerprint(file: File): string {
+  return `${file.webkitRelativePath || file.name}|${file.size}`;
+}
+// localStorage key for the folder being uploaded (null for flat file picks).
+// Uses localStorage so the cache survives page refreshes.
+function uploadCacheKey(files: File[]): string | null {
+  const root = files[0]?.webkitRelativePath?.split("/")[0];
+  return root ? `upload_done_${root}` : null;
+}
+function loadDoneSet(key: string | null): Set<string> {
+  if (!key) return new Set();
+  try {
+    return new Set(JSON.parse(localStorage.getItem(key) ?? "[]") as string[]);
+  } catch {
+    return new Set();
+  }
+}
+function saveDoneSet(key: string | null, done: Set<string>) {
+  if (!key) return;
+  try {
+    localStorage.setItem(key, JSON.stringify([...done]));
+  } catch { /* storage full — ignore */ }
+}
+
 type Mode = "files" | "folder";
 type Phase = "idle" | "uploading" | "processing" | "done" | "failed";
 
@@ -37,6 +64,7 @@ export default function UploadPage() {
   const [uploadStats, setUploadStats] = useState<{
     speed: number; loaded: number; total: number;
   } | null>(null);
+  const [skippedCount, setSkippedCount] = useState(0);
 
   const filesRef = useRef<HTMLInputElement>(null);
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -83,57 +111,115 @@ export default function UploadPage() {
     setPhase("uploading");
     setUploadPercent(0);
     setUploadStats(null);
+    setSkippedCount(0);
     uploadStartRef.current = Date.now();
 
-    // For folder uploads, preserve the relative paths; for file uploads these are empty.
-    const paths = selectedFiles.map((f) => f.webkitRelativePath ?? "");
+    // Skip files already confirmed uploaded in a previous attempt this session.
+    const cacheKey = uploadCacheKey(selectedFiles);
+    const done = loadDoneSet(cacheKey);
+    const pairs = selectedFiles
+      .map((f) => ({ file: f, path: f.webkitRelativePath ?? "" }))
+      .filter((p) => !done.has(fingerprint(p.file)));
 
-    let jobId: string;
-    try {
-      jobId = await startDirectUpload(token, selectedFiles, paths, null, (percent, loaded, total) => {
-        setUploadPercent(percent);
-        const elapsed = (Date.now() - uploadStartRef.current) / 1000;
-        const speed = elapsed > 0 ? loaded / elapsed : 0;
-        setUploadStats({ speed, loaded, total });
-      });
-    } catch (err) {
-      if (err instanceof UploadPreflightError) {
-        // All files failed validation — synthesise a job result and show the error panel
-        setJob({
-          job_id: "",
-          status: "failed",
-          total: err.errors.length,
-          processed: 0,
-          duplicates: 0,
-          errors: err.errors,
-        });
-        setPhase("failed");
-      } else {
-        setErrorMessage(err instanceof Error ? err.message : "Upload failed");
-        setPhase("idle");
-      }
+    const skipped = selectedFiles.length - pairs.length;
+    setSkippedCount(skipped);
+
+    if (pairs.length === 0) {
+      // Every file was already uploaded — jump straight to done.
+      setJob({ job_id: "", status: "done", total: 0, processed: 0, duplicates: selectedFiles.length, errors: [] });
+      setPhase("done");
       return;
+    }
+
+    const filesToUpload = pairs.map((p) => p.file);
+    const pathsToUpload = pairs.map((p) => p.path);
+    const totalBytes = filesToUpload.reduce((sum, f) => sum + f.size, 0);
+
+    // Split into batches so no single POST carries the whole folder.
+    const batches: Array<{ files: File[]; paths: string[] }> = [];
+    for (let i = 0; i < filesToUpload.length; i += BATCH_SIZE) {
+      batches.push({
+        files: filesToUpload.slice(i, i + BATCH_SIZE),
+        paths: pathsToUpload.slice(i, i + BATCH_SIZE),
+      });
+    }
+
+    const jobIds: string[] = [];
+    let bytesBeforeBatch = 0;
+
+    for (const batch of batches) {
+      let jobId: string;
+      try {
+        jobId = await startDirectUpload(
+          token,
+          batch.files,
+          batch.paths,
+          null,
+          (_percent, batchLoaded) => {
+            const overallLoaded = bytesBeforeBatch + batchLoaded;
+            const percent = totalBytes > 0 ? Math.round((overallLoaded / totalBytes) * 100) : 0;
+            const elapsed = (Date.now() - uploadStartRef.current) / 1000;
+            const speed = elapsed > 0 ? overallLoaded / elapsed : 0;
+            setUploadPercent(percent);
+            setUploadStats({ speed, loaded: overallLoaded, total: totalBytes });
+          }
+        );
+      } catch (err) {
+        if (err instanceof UploadPreflightError) {
+          setJob({
+            job_id: "",
+            status: "failed",
+            total: err.errors.length,
+            processed: 0,
+            duplicates: 0,
+            errors: err.errors,
+          });
+          setPhase("failed");
+        } else {
+          setErrorMessage(err instanceof Error ? err.message : "Upload failed");
+          setPhase("idle");
+        }
+        return;
+      }
+      jobIds.push(jobId);
+
+      // Persist fingerprints so a retry can skip this batch.
+      batch.files.forEach((f) => done.add(fingerprint(f)));
+      saveDoneSet(cacheKey, done);
+
+      bytesBeforeBatch += batch.files.reduce((sum, f) => sum + f.size, 0);
     }
 
     setPhase("processing");
     processingStartRef.current = Date.now();
-    pollJob(token, jobId);
+    pollJobs(token, jobIds);
   }
 
-  function pollJob(authToken: string, jobId: string) {
+  function pollJobs(authToken: string, jobIds: string[]) {
     async function tick() {
       try {
-        const status = await getImportJob(authToken, jobId);
-        setJob(status);
-        if (status.status === "done" || status.status === "failed") {
-          setPhase(status.status);
+        const statuses = await Promise.all(jobIds.map((id) => getImportJob(authToken, id)));
+        const allDone = statuses.every((s) => s.status === "done" || s.status === "failed");
+        const anyFailed = statuses.some((s) => s.status === "failed");
+        const knownTotal = statuses.some((s) => s.total != null)
+          ? statuses.reduce((sum, s) => sum + (s.total ?? 0), 0)
+          : null;
+        const aggregated: ImportJobStatus = {
+          job_id: jobIds[0],
+          status: allDone ? (anyFailed ? "failed" : "done") : "processing",
+          total: knownTotal,
+          processed: statuses.reduce((sum, s) => sum + s.processed, 0),
+          duplicates: statuses.reduce((sum, s) => sum + s.duplicates, 0),
+          errors: statuses.flatMap((s) => s.errors),
+        };
+        setJob(aggregated);
+        if (allDone) {
+          setPhase(anyFailed ? "failed" : "done");
         } else {
           pollRef.current = setTimeout(tick, 2000);
         }
       } catch (err) {
-        setErrorMessage(
-          err instanceof Error ? err.message : "Failed to fetch job status"
-        );
+        setErrorMessage(err instanceof Error ? err.message : "Failed to fetch job status");
         setPhase("failed");
       }
     }
@@ -239,6 +325,9 @@ export default function UploadPage() {
       {phase === "uploading" && (
         <div className="flex flex-col items-center gap-3 w-full max-w-sm">
           <p className="text-sm text-gray-600">Uploading… {uploadPercent}%</p>
+          {skippedCount > 0 && (
+            <p className="text-xs text-green-600">{skippedCount.toLocaleString()} files skipped (already uploaded)</p>
+          )}
           <div className="w-full h-3 rounded-full bg-gray-200">
             <div
               className="h-3 rounded-full bg-blue-500 transition-all duration-200"


### PR DESCRIPTION
## Summary

- **OOM crash at ~3GB**: `await upload.read()` was loading entire files into RAM as `bytes`. Fixed by reading only 512 bytes for MIME detection, measuring size via `seek()`, and streaming `upload.file` directly to S3.
- **400 at ~1000 files**: python-multipart's default `max_files=1000` was hit. Fixed by parsing via `request.form(max_files=50_000, max_part_size=5GB)` — FastAPI constructor kwargs for multipart are silently stored in `app.extra` and never applied by starlette 1.0.
- **isinstance always False**: `request.form()` returns `starlette.datastructures.UploadFile` instances; FastAPI's `UploadFile` is a subclass, so the check was always `False`. Fixed by importing and checking against the starlette base class.
- **Single huge request**: All files were sent in one multipart POST. Fixed by batching at 200 files per request on the frontend.
- **Slow retries**: Failed uploads required re-uploading everything. Fixed by caching uploaded file fingerprints (`path|size`) in `localStorage` — retrying the same folder skips already-completed batches instantly.

## Test plan

- [ ] Upload a small folder (< 200 files) — should complete normally
- [ ] Upload a large folder (> 1000 files) — should batch and complete without 400
- [ ] Interrupt a large upload midway, retry — skipped count shown, only remaining files uploaded
- [ ] Upload a single large video file (> 1MB) — should not 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)