### PR TITLE
fix: apply live photo sidecar to both HEIC and MP4 companions

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -459,3 +459,44 @@ async def backfill_metadata(
         backfill_user_metadata.delay(str(uid))
 
     return BackfillMetadataResponse(enqueued=len(user_ids))
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/backfill-live-photo-dates
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/backfill-live-photo-dates",
+    response_model=BackfillMetadataResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def backfill_live_photo_dates(
+    user_id: uuid.UUID | None = Query(
+        default=None,
+        description="Limit backfill to a specific user. Omit to run for all users.",
+    ),
+    admin_id: uuid.UUID = Depends(get_admin_user),
+    session: AsyncSession = Depends(get_session),
+) -> BackfillMetadataResponse:
+    """Fix captured_at on live photo MP4/MOV assets imported without a sidecar.
+
+    For each video asset with sidecar_missing=True, finds the matching HEIC/HEIF
+    photo by stem name and copies its captured_at.  Idempotent — safe to re-run.
+    Returns the number of per-user tasks enqueued.
+    """
+    from app.worker.metadata_tasks import backfill_live_photo_dates as _task
+
+    if user_id is not None:
+        user = await session.scalar(select(User).where(User.id == user_id))
+        if user is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+        user_ids = [user_id]
+    else:
+        rows = await session.scalars(select(User.id))
+        user_ids = list(rows)
+
+    for uid in user_ids:
+        _task.delay(str(uid))
+
+    return BackfillMetadataResponse(enqueued=len(user_ids))

--- a/backend/app/worker/metadata_tasks.py
+++ b/backend/app/worker/metadata_tasks.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from pathlib import PurePosixPath
 
 from geoalchemy2.functions import ST_MakePoint
 from sqlalchemy import select, text
@@ -155,6 +156,68 @@ def backfill_user_metadata(self, owner_id: str) -> None:
         backfill_asset_metadata.delay(str(asset_id), owner_id)
 
     logger.info("Backfill: enqueued %d asset task(s) for user %s", count, owner_id)
+
+
+@celery_app.task(name="backfill.live_photo_dates", bind=True, max_retries=0)
+def backfill_live_photo_dates(self, owner_id: str) -> None:
+    """Fix captured_at on live photo MP4/MOV assets imported without a sidecar.
+
+    For each video asset (MP4/MOV) with sidecar_missing=True, finds a photo
+    asset (HEIC/HEIF/JPEG) owned by the same user whose original_filename stem
+    matches.  Copies captured_at from the photo to the video and clears
+    sidecar_missing.  Idempotent — safe to re-run.
+    """
+    asyncio.run(_run_live_photo_backfill(uuid.UUID(owner_id)))
+
+
+async def _run_live_photo_backfill(owner_id: uuid.UUID) -> None:
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    try:
+        async with async_sessionmaker(engine, expire_on_commit=False)() as session:
+            await _set_rls(session, owner_id)
+
+            video_rows = await session.scalars(
+                select(MediaAsset).where(
+                    MediaAsset.owner_id == owner_id,
+                    MediaAsset.mime_type.in_(["video/mp4", "video/quicktime"]),
+                    MediaAsset.sidecar_missing == True,  # noqa: E712
+                )
+            )
+            videos = list(video_rows)
+            if not videos:
+                logger.info("Live photo backfill: no sidecar_missing videos for user %s", owner_id)
+                return
+
+            photo_rows = await session.scalars(
+                select(MediaAsset).where(
+                    MediaAsset.owner_id == owner_id,
+                    MediaAsset.mime_type.in_(["image/heic", "image/heif", "image/jpeg", "image/png"]),
+                    MediaAsset.sidecar_missing == False,  # noqa: E712
+                    MediaAsset.captured_at.is_not(None),
+                )
+            )
+            # Build stem → captured_at map from photos that have a sidecar date.
+            photo_stem_map: dict[str, object] = {}
+            for photo in photo_rows:
+                stem = PurePosixPath(photo.original_filename).stem.lower()
+                photo_stem_map[stem] = photo.captured_at
+
+            updated = 0
+            for video in videos:
+                stem = PurePosixPath(video.original_filename).stem.lower()
+                photo_date = photo_stem_map.get(stem)
+                if photo_date is not None:
+                    video.captured_at = photo_date
+                    video.sidecar_missing = False
+                    updated += 1
+
+            await session.commit()
+            logger.info(
+                "Live photo backfill: updated %d / %d video assets for user %s",
+                updated, len(videos), owner_id,
+            )
+    finally:
+        await engine.dispose()
 
 
 @celery_app.task(

--- a/backend/app/worker/takeout_tasks.py
+++ b/backend/app/worker/takeout_tasks.py
@@ -495,12 +495,23 @@ async def _ingest_one(
             # Sidecar lookup — try standard ".json" name, truncated variant, and the
             # ".supplemental-metadata.json" variant used by some Takeout exports.
             sidecar_data: dict | None = None
-            for candidate in (
+            _p = PurePosixPath(media_name)
+            _stem = _p.stem
+            _dir = str(_p.parent)
+            _dir_prefix = "" if _dir == "." else _dir + "/"
+            _sidecar_candidates: list[str] = [
                 _sidecar_name(media_name),
                 _sidecar_name(Path(media_name).name),
                 media_name + _SUPPLEMENTAL_SIDECAR_EXT,
                 Path(media_name).name + _SUPPLEMENTAL_SIDECAR_EXT,
-            ):
+            ]
+            # Live photo companion: iPhone MP4/MOV shares its stem with the HEIC/HEIF still.
+            # Try swapping the extension to find the photo's sidecar (e.g. IMG_4833.HEIC.json).
+            for _photo_ext in (".heic", ".heif", ".jpg", ".jpeg"):
+                _companion = _dir_prefix + _stem + _photo_ext
+                _sidecar_candidates.append(_companion + _SUPPLEMENTAL_SIDECAR_EXT)
+                _sidecar_candidates.append(_companion + _SIDECAR_EXT)
+            for candidate in _sidecar_candidates:
                 if candidate.lower() in sidecar_set:
                     try:
                         raw_bytes = zf.read(candidate) if candidate in zf.namelist() else None
@@ -792,12 +803,19 @@ async def _ingest_one_from_path(
             # Sidecar: look for {filename}.json (or .supplemental-metadata.json) adjacent
             # to the media file. Try standard and supplemental-metadata naming variants.
             sidecar_data: dict | None = None
-            for candidate_name in (
+            _fname_stem = PurePosixPath(file_path.name).stem
+            _sidecar_candidates_path: list[str] = [
                 _sidecar_name(file_path.name),
                 _sidecar_name(PurePosixPath(file_path.name).name),
                 file_path.name + _SUPPLEMENTAL_SIDECAR_EXT,
                 PurePosixPath(file_path.name).name + _SUPPLEMENTAL_SIDECAR_EXT,
-            ):
+            ]
+            # Live photo companion: iPhone MP4/MOV shares its stem with the HEIC/HEIF still.
+            for _photo_ext in (".heic", ".heif", ".jpg", ".jpeg"):
+                _companion_name = _fname_stem + _photo_ext
+                _sidecar_candidates_path.append(_companion_name + _SUPPLEMENTAL_SIDECAR_EXT)
+                _sidecar_candidates_path.append(_companion_name + _SIDECAR_EXT)
+            for candidate_name in _sidecar_candidates_path:
                 candidate_path = file_path.parent / candidate_name
                 if candidate_path.exists():
                     try:

--- a/backend/app/worker/upload_tasks.py
+++ b/backend/app/worker/upload_tasks.py
@@ -387,6 +387,13 @@ async def _run_direct_upload(job_id: uuid.UUID, owner_id: uuid.UUID) -> None:
                 rel_path: str = entry.get("rel_path", "")
 
                 parsed_sidecar = sidecar_lookup.get(filename.lower())
+                # Live photo companion fallback: MP4/MOV shares stem with HEIC/HEIF sidecar.
+                if parsed_sidecar is None:
+                    _stem = PurePosixPath(filename).stem.lower()
+                    for _photo_ext in (".heic", ".heif", ".jpg", ".jpeg"):
+                        parsed_sidecar = sidecar_lookup.get(_stem + _photo_ext)
+                        if parsed_sidecar is not None:
+                            break
 
                 # Download staged file from S3
                 try:


### PR DESCRIPTION
## Summary
- iPhone Live Photo exports have one sidecar named after the HEIC (e.g. `IMG_4833.HEIC.supplemental-metadata.json`). Previously only the HEIC got the date; the MP4 companion landed with `sidecar_missing=True` and `captured_at=now()`.
- Extended sidecar candidate lookup in all three ingest paths (Takeout ZIP, Takeout folder, direct upload) to try swapping the file extension to `.heic/.heif/.jpg/.jpeg` when no direct sidecar match is found.
- Added `backfill.live_photo_dates` Celery task + `POST /admin/backfill-live-photo-dates` endpoint to retroactively fix already-imported MP4s by matching them to their HEIC partner by stem name.

## Test plan
- [ ] Import a Google Takeout zip containing a Live Photo pair — MP4 should now get the correct `captured_at` from the HEIC sidecar
- [ ] Import via folder upload — same result
- [ ] Direct upload with `.heic` + `.mp4` + `.heic.supplemental-metadata.json` — MP4 gets correct date
- [ ] Call `POST /admin/backfill-live-photo-dates` — existing sidecar_missing MP4s updated, check date in feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)