### PR TITLE
Fix: close photo modal when clicking outside

### DIFF
--- a/frontend/src/app/@modal/(.)assets/[id]/page.tsx
+++ b/frontend/src/app/@modal/(.)assets/[id]/page.tsx
@@ -28,7 +28,7 @@ export default function PhotoModal() {
       />
 
       {/* Scrollable area so tall content (metadata sidebar) is reachable */}
-      <div className="absolute inset-0 overflow-y-auto">
+      <div className="absolute inset-0 overflow-y-auto" onClick={() => router.back()}>
         <div className="flex min-h-full items-start justify-center px-4 py-8">
           <div
             className="relative w-full max-w-6xl overflow-hidden rounded-lg bg-white shadow-2xl"


### PR DESCRIPTION
Small follow-up to #153.

The backdrop `onClick` was behind the scrollable container div in z-order, so clicks on the dark area around the panel weren't reaching it. Moved the `router.back()` handler to the scrollable container instead — the panel's `stopPropagation` ensures clicks inside the photo don't bubble up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)