### PR TITLE
feat: people page — browse photos by tagged person

### DIFF
--- a/backend/app/api/assets.py
+++ b/backend/app/api/assets.py
@@ -2,8 +2,8 @@
 
 Endpoints:
   GET /assets               — paginated timeline ordered by captured_at DESC, id DESC.
-                              Optional filters: person, date_from, date_to, media_type, has_location,
-                              near (lat,lon), radius_km, bbox (minLon,minLat,maxLon,maxLat).
+                              Optional filters: person, person_id, date_from, date_to, media_type,
+                              has_location, near (lat,lon), radius_km, bbox (minLon,minLat,maxLon,maxLat).
                               Cursor-based pagination; each response includes a next_cursor field.
                               When near or bbox is specified, results are ordered by captured_at DESC
                               and next_cursor is always null (no cursor pagination for geo queries).
@@ -191,6 +191,7 @@ async def list_assets(
     limit: int = Query(_DEFAULT_PAGE_SIZE, ge=1, le=_MAX_PAGE_SIZE, description="Page size"),
     # Filters
     person: str | None = Query(None, description="Filter by person name (case-insensitive, google_people source)"),
+    person_id: uuid.UUID | None = Query(None, description="Filter by person tag UUID (google_people source)"),
     date_from: datetime | None = Query(None, description="Only assets with captured_at >= this value"),
     date_to: datetime | None = Query(None, description="Only assets with captured_at <= this value"),
     media_type: Literal["photo", "video"] | None = Query(None, description="Filter by media type"),
@@ -225,8 +226,19 @@ async def list_assets(
         .where(MediaAsset.owner_id == user_id)
     )
 
-    # Person filter
-    if person is not None:
+    # Person filter — by name (ilike) or by tag UUID.
+    # person_id takes precedence when both are supplied.
+    if person_id is not None:
+        stmt = (
+            stmt
+            .join(AssetTag, AssetTag.asset_id == MediaAsset.id)
+            .join(Tag, Tag.id == AssetTag.tag_id)
+            .where(
+                AssetTag.source == _GOOGLE_PEOPLE_SOURCE,
+                Tag.id == person_id,
+            )
+        )
+    elif person is not None:
         stmt = (
             stmt
             .join(AssetTag, AssetTag.asset_id == MediaAsset.id)

--- a/backend/app/api/people.py
+++ b/backend/app/api/people.py
@@ -1,0 +1,125 @@
+"""People API: list all people tagged in the authenticated user's photos.
+
+People are derived from tags with source='google_people', written during Google
+Takeout import.  No separate DB table is needed — the existing tags /
+asset_tags schema carries all the data.
+
+Endpoints:
+  GET /people  — list all people ordered alphabetically by name, with photo
+                 count and a cover thumbnail URL (most recently captured photo
+                 for that person).
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_current_user
+from app.db import get_authed_session
+from app.models.media import MediaAsset
+from app.models.tag import AssetTag, Tag
+from app.services.storage import StorageError, storage_service
+
+router = APIRouter(prefix="/people", tags=["people"])
+
+_GOOGLE_PEOPLE_SOURCE = "google_people"
+_THUMBNAIL_KEY_TEMPLATE = "{user_id}/thumbnails/{asset_id}/thumb.webp"
+
+
+# ---------------------------------------------------------------------------
+# Response model
+# ---------------------------------------------------------------------------
+
+
+class PersonItem(BaseModel):
+    id: uuid.UUID
+    name: str
+    photo_count: int
+    cover_thumbnail_url: str | None
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=list[PersonItem])
+async def list_people(
+    user_id: uuid.UUID = Depends(get_current_user),
+    session: AsyncSession = Depends(get_authed_session),
+) -> list[PersonItem]:
+    """Return all people tagged in the authenticated user's photos.
+
+    People are derived from tags that have at least one asset_tag with
+    source='google_people'.  Results are ordered alphabetically by name.
+
+    RLS ensures all results are scoped to the authenticated user.
+    """
+    # Step 1: all people tags with photo counts, ordered by name.
+    count_stmt = (
+        select(Tag.id, Tag.name, func.count(AssetTag.asset_id).label("photo_count"))
+        .join(
+            AssetTag,
+            and_(AssetTag.tag_id == Tag.id, AssetTag.source == _GOOGLE_PEOPLE_SOURCE),
+        )
+        .where(Tag.owner_id == user_id)
+        .group_by(Tag.id, Tag.name)
+        .order_by(Tag.name)
+    )
+    rows = list(await session.execute(count_stmt))
+    if not rows:
+        return []
+
+    # Step 2: most recent asset per person for the cover thumbnail.
+    # DISTINCT ON (tag_id) + ORDER BY tag_id, captured_at DESC gives exactly
+    # one row per tag — the one with the latest captured_at.
+    tag_ids = [row.id for row in rows]
+    cover_stmt = (
+        select(
+            AssetTag.tag_id,
+            MediaAsset.id.label("asset_id"),
+            MediaAsset.thumbnail_ready,
+        )
+        .join(MediaAsset, MediaAsset.id == AssetTag.asset_id)
+        .where(
+            AssetTag.tag_id.in_(tag_ids),
+            AssetTag.source == _GOOGLE_PEOPLE_SOURCE,
+        )
+        .distinct(AssetTag.tag_id)
+        .order_by(AssetTag.tag_id, MediaAsset.captured_at.desc().nulls_last())
+    )
+    cover_rows = list(await session.execute(cover_stmt))
+    covers: dict[uuid.UUID, tuple[uuid.UUID, bool]] = {
+        row.tag_id: (row.asset_id, row.thumbnail_ready) for row in cover_rows
+    }
+
+    # Step 3: build response, generating presigned thumbnail URLs in Python.
+    result: list[PersonItem] = []
+    for row in rows:
+        cover_thumbnail_url: str | None = None
+        if row.id in covers:
+            cover_asset_id, thumbnail_ready = covers[row.id]
+            if thumbnail_ready:
+                key = _THUMBNAIL_KEY_TEMPLATE.format(
+                    user_id=user_id, asset_id=cover_asset_id
+                )
+                try:
+                    cover_thumbnail_url = storage_service.generate_presigned_url(
+                        str(user_id), key
+                    )
+                except StorageError:
+                    pass
+
+        result.append(
+            PersonItem(
+                id=row.id,
+                name=row.name,
+                photo_count=row.photo_count,
+                cover_thumbnail_url=cover_thumbnail_url,
+            )
+        )
+
+    return result

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.assets import router as assets_router
 from app.api.auth import router as auth_router
 from app.api.import_ import router as import_router
 from app.api.map import router as map_router
+from app.api.people import router as people_router
 from app.api.shares import router as shares_router
 from app.api.upload import router as upload_router
 from app.api.users import router as users_router
@@ -84,6 +85,7 @@ app.include_router(import_router)
 app.include_router(upload_router)
 app.include_router(assets_router)
 app.include_router(albums_router)
+app.include_router(people_router)
 app.include_router(map_router)
 
 

--- a/backend/app/worker/upload_tasks.py
+++ b/backend/app/worker/upload_tasks.py
@@ -8,7 +8,8 @@ Processing pipeline per uploaded file:
   5. Write MediaAsset row + increment users.storage_used_bytes
   6. Extract EXIF → set asset.captured_at
   7. apply_exif → write MediaMetadata row
-  8. Insert Location row from EXIF GPS + dispatch geocode task
+  8. apply_sidecar (when sidecar present) → description, people tags, raw JSON, sidecar GPS
+  9. Insert Location row from EXIF GPS (only when no sidecar GPS) + dispatch geocode task
   9. Album linking:
      - If rel_path has directory components → ensure album hierarchy (rooted at
        target_album_id when provided)
@@ -45,7 +46,7 @@ from app.models.media import Location, MediaAsset
 from app.services.exif import apply_exif, extract_exif
 from app.services.metadata_merge import merge_metadata
 from app.services.storage import StorageError, storage_service
-from app.services.takeout_sidecar import ParsedSidecar, parse_sidecar
+from app.services.takeout_sidecar import ParsedSidecar, apply_sidecar, parse_sidecar
 from app.services.upload_validation import ALLOWED_MIME_TYPES
 from app.worker.celery_app import celery_app
 
@@ -219,6 +220,16 @@ async def _ingest_one(
                 existing_asset = await session.get(MediaAsset, existing)
                 if existing_asset is not None:
                     existing_asset.captured_at = canonical.captured_at
+            # Apply remaining sidecar data: description, people tags, raw JSON, GPS.
+            # This backfills people tags for photos already in the library.
+            try:
+                await apply_sidecar(
+                    session, asset_id=existing, owner_id=owner_id, parsed=parsed_sidecar
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Could not apply sidecar to duplicate asset %s: %s", existing, exc
+                )
         logger.debug("Skipping duplicate %s (checksum %s)", filename, checksum)
         job.duplicates += 1
         dir_part = str(PurePosixPath(rel_path).parent) if rel_path else ""
@@ -334,9 +345,25 @@ async def _ingest_one(
             session.add(asset)
             await apply_exif(session, asset_id=asset_id, result=exif_result)
 
-            # Insert location from EXIF GPS (same pattern as metadata_tasks._apply_metadata)
+            # Apply sidecar: description, people tags, raw JSON, and sidecar GPS.
+            # Runs before the EXIF GPS insert; sidecar GPS uses ON CONFLICT DO UPDATE
+            # so it takes precedence when both sources are present.
+            if parsed_sidecar is not None:
+                await apply_sidecar(
+                    session, asset_id=asset_id, owner_id=owner_id, parsed=parsed_sidecar
+                )
+
+            # Location for geocoding: prefer sidecar GPS, fall back to EXIF GPS.
+            # apply_sidecar already wrote the location row when has_geo is True, so only
+            # insert from EXIF when the sidecar had no GPS (ON CONFLICT DO NOTHING is safe).
             new_location = False
-            if exif_result.gps_latitude is not None and exif_result.gps_longitude is not None:
+            _geocode_lat: float | None = None
+            _geocode_lon: float | None = None
+            if parsed_sidecar is not None and parsed_sidecar.has_geo:
+                new_location = True
+                _geocode_lat = parsed_sidecar.latitude
+                _geocode_lon = parsed_sidecar.longitude
+            elif exif_result.gps_latitude is not None and exif_result.gps_longitude is not None:
                 from geoalchemy2.functions import ST_MakePoint
                 stmt = (
                     pg_insert(Location)
@@ -349,6 +376,8 @@ async def _ingest_one(
                 )
                 await session.execute(stmt)
                 new_location = True
+                _geocode_lat = exif_result.gps_latitude
+                _geocode_lon = exif_result.gps_longitude
 
             # Album linking
             dir_part = str(PurePosixPath(rel_path).parent) if rel_path else ""
@@ -371,11 +400,11 @@ async def _ingest_one(
         from app.worker.thumbnail_tasks import generate_thumbnails
         generate_thumbnails.delay(str(asset_id), str(owner_id))
 
-        if new_location and exif_result.gps_latitude is not None:
+        if new_location and _geocode_lat is not None:
             from app.worker.geocode_tasks import resolve_asset_geocode
             resolve_asset_geocode.delay(
                 str(asset_id), str(owner_id),
-                exif_result.gps_latitude, exif_result.gps_longitude,
+                _geocode_lat, _geocode_lon,
             )
 
     except Exception as exc:
@@ -595,6 +624,17 @@ async def _run_direct_upload(job_id: uuid.UUID, owner_id: uuid.UUID) -> None:
                     if existing_asset is not None:
                         existing_asset.captured_at = canonical.captured_at
                         logger.info("Updated captured_at for %s from sidecar", media_filename_lower)
+                        try:
+                            await apply_sidecar(
+                                session,
+                                asset_id=existing_asset.id,
+                                owner_id=owner_id,
+                                parsed=sidecar,
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                "Could not apply sidecar to %s: %s", media_filename_lower, exc
+                            )
                 await session.commit()
                 await session.execute(text(f"SET LOCAL app.current_user_id = '{owner_id}'"))
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -573,6 +573,9 @@ export default function Home() {
           <Link href="/albums" className="text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">
             Albums
           </Link>
+          <Link href="/people" className="text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">
+            People
+          </Link>
           <Link href="/map" className="text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">
             Map
           </Link>

--- a/frontend/src/app/people/[id]/page.tsx
+++ b/frontend/src/app/people/[id]/page.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+// Person detail page — justified grid of all photos featuring a specific person.
+// Route: /people/[id]
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
+import { getAssets, listPeople, AssetItem, PersonItem } from "@/lib/api";
+import { MediaCard } from "@/components/MediaCard";
+
+// ─── Layout constants ──────────────────────────────────────────────────────────
+
+const TARGET_ROW_HEIGHT = 200; // px
+
+// ─── Justified-layout helpers ──────────────────────────────────────────────────
+
+interface RenderedDims {
+  width: number;
+  height: number;
+}
+
+function justifyRow(
+  assets: AssetItem[],
+  containerWidth: number,
+  targetRowHeight: number,
+  isPartialRow: boolean
+): RenderedDims[] {
+  if (assets.length === 0) return [];
+  const aspectRatios = assets.map((a) =>
+    a.width && a.height ? a.width / a.height : 1
+  );
+  const totalAspect = aspectRatios.reduce((s, ar) => s + ar, 0);
+  const rowHeight = isPartialRow ? targetRowHeight : containerWidth / totalAspect;
+  return aspectRatios.map((ar) => ({
+    width: Math.floor(ar * rowHeight),
+    height: Math.floor(rowHeight),
+  }));
+}
+
+interface AssetRow {
+  assets: AssetItem[];
+  isPartial: boolean;
+}
+
+function buildRows(
+  assets: AssetItem[],
+  containerWidth: number,
+  targetHeight: number
+): AssetRow[] {
+  if (containerWidth === 0) return [];
+  const rows: AssetRow[] = [];
+  let current: AssetItem[] = [];
+  let aspectSum = 0;
+
+  for (const asset of assets) {
+    const ar = asset.width && asset.height ? asset.width / asset.height : 1;
+    current.push(asset);
+    aspectSum += ar;
+    if (containerWidth / aspectSum <= targetHeight) {
+      rows.push({ assets: current, isPartial: false });
+      current = [];
+      aspectSum = 0;
+    }
+  }
+  if (current.length > 0) rows.push({ assets: current, isPartial: true });
+  return rows;
+}
+
+// ─── Day grouping ──────────────────────────────────────────────────────────────
+
+interface DayGroup {
+  date: string;
+  label: string;
+  locationSummary: string;
+  assets: AssetItem[];
+}
+
+function groupByDay(items: AssetItem[]): DayGroup[] {
+  const map = new Map<string, AssetItem[]>();
+  for (const item of items) {
+    const date = item.captured_at ? item.captured_at.slice(0, 10) : "unknown";
+    if (!map.has(date)) map.set(date, []);
+    map.get(date)!.push(item);
+  }
+  return Array.from(map.entries()).map(([date, assets]) => {
+    const label =
+      date === "unknown"
+        ? "Unknown date"
+        : new Date(date + "T12:00:00").toLocaleDateString("en-GB", {
+            weekday: "short",
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+          });
+    const localities = Array.from(
+      new Set(assets.map((a) => a.locality).filter((l): l is string => !!l))
+    );
+    let locationSummary = "";
+    if (localities.length === 1) locationSummary = localities[0];
+    else if (localities.length === 2) locationSummary = `${localities[0]} & ${localities[1]}`;
+    else if (localities.length > 2)
+      locationSummary = `${localities[0]} & ${localities.length - 1} more`;
+    return { date, label, locationSummary, assets };
+  });
+}
+
+// ─── Sub-components ────────────────────────────────────────────────────────────
+
+function JustifiedRow({
+  row,
+  containerWidth,
+  token,
+}: {
+  row: AssetRow;
+  containerWidth: number;
+  token: string;
+}) {
+  const dims = justifyRow(row.assets, containerWidth, TARGET_ROW_HEIGHT, row.isPartial);
+  return (
+    <div className="flex gap-0.5">
+      {row.assets.map((asset, i) => (
+        <div
+          key={asset.id}
+          className="flex-shrink-0"
+          style={{ width: dims[i].width, height: dims[i].height }}
+        >
+          <MediaCard
+            asset={asset}
+            width={dims[i].width}
+            height={dims[i].height}
+            token={token}
+            onClick={() => {}}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DaySection({
+  group,
+  containerWidth,
+  token,
+}: {
+  group: DayGroup;
+  containerWidth: number;
+  token: string;
+}) {
+  const rows = buildRows(group.assets, containerWidth, TARGET_ROW_HEIGHT);
+  return (
+    <section className="mb-6">
+      <div className="mb-2 flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-200">{group.label}</h2>
+        {group.locationSummary && (
+          <span className="text-xs text-gray-400 dark:text-gray-500">{group.locationSummary}</span>
+        )}
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {rows.map((row, i) => (
+          <JustifiedRow key={i} row={row} containerWidth={containerWidth} token={token} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export default function PersonPage() {
+  const { token, ready } = useAuth();
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const personId = params.id;
+
+  const [person, setPerson] = useState<PersonItem | null>(null);
+  const [items, setItems] = useState<AssetItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  const gridRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (ready && !token) router.replace("/login");
+  }, [ready, token, router]);
+
+  // Measure grid container width for justified layout.
+  useLayoutEffect(() => {
+    const el = gridRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      setContainerWidth(Math.floor(entries[0]?.contentRect.width ?? 0));
+    });
+    ro.observe(el);
+    setContainerWidth(Math.floor(el.getBoundingClientRect().width));
+    return () => ro.disconnect();
+  }, []);
+
+  // Initial load: person info + first page of photos.
+  useEffect(() => {
+    if (!ready || !token) return;
+    setLoading(true);
+    Promise.all([
+      listPeople(token),
+      getAssets(token, undefined, 50, undefined, undefined, personId),
+    ])
+      .then(([people, page]) => {
+        setPerson(people.find((p) => p.id === personId) ?? null);
+        setItems(page.items);
+        setNextCursor(page.next_cursor);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"))
+      .finally(() => setLoading(false));
+  }, [ready, token, personId]);
+
+  // Load next page.
+  const loadMore = useCallback(async () => {
+    if (!token || !nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const page = await getAssets(token, nextCursor, 50, undefined, undefined, personId);
+      setItems((prev) => [...prev, ...page.items]);
+      setNextCursor(page.next_cursor);
+    } catch {
+      // silently ignore — user can scroll again to retry
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [token, nextCursor, loadingMore, personId]);
+
+  // Infinite scroll sentinel.
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) loadMore();
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [loadMore]);
+
+  if (!ready || !token) return null;
+
+  const dayGroups = groupByDay(items);
+  const photoCount = person?.photo_count ?? items.length;
+
+  return (
+    <main className="min-h-screen bg-white px-4 py-6 dark:bg-gray-900">
+      {/* Header */}
+      <div className="mb-6 flex items-center gap-4">
+        <Link
+          href="/people"
+          className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+            <path fillRule="evenodd" d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z" clipRule="evenodd" />
+          </svg>
+          People
+        </Link>
+        <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          {person?.name ?? "Person"}
+        </h1>
+        {!loading && (
+          <span className="text-sm text-gray-400 dark:text-gray-500">
+            {photoCount} {photoCount === 1 ? "photo" : "photos"}
+          </span>
+        )}
+      </div>
+
+      {/* States */}
+      {error && (
+        <p className="mb-4 rounded bg-red-50 px-4 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </p>
+      )}
+      {loading && (
+        <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">Loading…</p>
+      )}
+      {!loading && items.length === 0 && !error && (
+        <p className="mt-24 text-center text-gray-400 dark:text-gray-500">No photos found.</p>
+      )}
+
+      {/* Justified grid */}
+      <div ref={gridRef}>
+        {!loading &&
+          dayGroups.map((group) => (
+            <DaySection
+              key={group.date}
+              group={group}
+              containerWidth={containerWidth}
+              token={token}
+            />
+          ))}
+      </div>
+
+      {/* Infinite scroll sentinel */}
+      {nextCursor && <div ref={sentinelRef} className="h-16" />}
+      {loadingMore && (
+        <p className="py-4 text-center text-sm text-gray-400 dark:text-gray-500">Loading more…</p>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/people/page.tsx
+++ b/frontend/src/app/people/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+// People index page — grid of everyone tagged in photos via Google Takeout.
+// Route: /people
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
+import { listPeople, PersonItem } from "@/lib/api";
+import { ThemeToggle } from "@/components/ThemeToggle";
+
+export default function PeoplePage() {
+  const { token, ready } = useAuth();
+  const router = useRouter();
+
+  const [people, setPeople] = useState<PersonItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (ready && !token) router.replace("/login");
+  }, [ready, token, router]);
+
+  useEffect(() => {
+    if (!ready || !token) return;
+    setLoading(true);
+    listPeople(token)
+      .then(setPeople)
+      .catch((e) => setError(e instanceof Error ? e.message : "Failed to load people"))
+      .finally(() => setLoading(false));
+  }, [ready, token]);
+
+  if (!ready || !token) return null;
+
+  return (
+    <main className="min-h-screen bg-white px-4 py-6 dark:bg-gray-900">
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link
+            href="/"
+            className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+              <path fillRule="evenodd" d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z" clipRule="evenodd" />
+            </svg>
+            Photos
+          </Link>
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">People</h1>
+        </div>
+        <ThemeToggle />
+      </div>
+
+      {/* States */}
+      {error && (
+        <p className="mb-4 rounded bg-red-50 px-4 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </p>
+      )}
+      {loading && (
+        <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">Loading…</p>
+      )}
+      {!loading && people.length === 0 && !error && (
+        <p className="mt-24 text-center text-gray-400 dark:text-gray-500">
+          No people found. Import photos from Google Takeout to see people here.
+        </p>
+      )}
+
+      {/* People grid */}
+      {!loading && people.length > 0 && (
+        <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+          {people.map((person) => (
+            <Link key={person.id} href={`/people/${person.id}`} className="group block">
+              {/* Avatar — circular crop */}
+              <div className="mx-auto aspect-square w-full max-w-[160px] overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+                {person.cover_thumbnail_url ? (
+                  <img
+                    src={person.cover_thumbnail_url}
+                    alt={person.name}
+                    className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+                    onError={(e) => {
+                      e.currentTarget.style.display = "none";
+                    }}
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-gray-300 dark:text-gray-600">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                      className="h-16 w-16"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                )}
+              </div>
+
+              {/* Name + count */}
+              <div className="mt-3 text-center">
+                <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {person.name}
+                </p>
+                <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+                  {person.photo_count} {person.photo_count === 1 ? "photo" : "photos"}
+                </p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -336,11 +336,13 @@ export async function getAssets(
   limit = 50,
   dateTo?: string,
   before?: string,
+  personId?: string,
 ): Promise<AssetsPage> {
   const params = new URLSearchParams({ limit: String(limit) });
   if (cursor) params.set("cursor", cursor);
   if (dateTo) params.set("date_to", dateTo);
   if (before) params.set("before", before);
+  if (personId) params.set("person_id", personId);
   const res = await fetch(`${CLIENT_API_URL}/assets?${params}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
@@ -638,6 +640,24 @@ export async function removeAssetFromAlbum(
     const data = await res.json().catch(() => ({}));
     throw new Error((data as { detail?: string }).detail ?? "Failed to remove from album");
   }
+}
+
+export interface PersonItem {
+  id: string;
+  name: string;
+  photo_count: number;
+  cover_thumbnail_url: string | null;
+}
+
+export async function listPeople(token: string): Promise<PersonItem[]> {
+  const res = await fetch(`${CLIENT_API_URL}/people`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error((data as { detail?: string }).detail ?? "Failed to load people");
+  }
+  return res.json();
 }
 
 export async function createInvitation(


### PR DESCRIPTION
## Summary
- New `/people` page: circular avatar grid of everyone tagged via Google Takeout, ordered alphabetically with photo count
- New `/people/[id]` page: justified day-grouped grid with cursor-based infinite scroll (same layout as main feed)
- `GET /people` API endpoint: returns people tags with photo count and cover thumbnail URL
- `GET /assets` gains `person_id` UUID filter for safe URL routing (no encoding edge cases)
- `upload_tasks`: `apply_sidecar` now called on all three ingest paths (new asset, checksum duplicate, retroactive filename match) — folder re-uploads now backfill people tags, description, and GPS for existing photos

## Test plan
- [ ] Log in and go to `/people` — should show a grid of people if Google Takeout photos with `people[]` in their sidecars have been imported
- [ ] Click a person — should show their photos in the justified grid
- [ ] Re-upload a Google Takeout folder containing `.json` sidecars with `people[]` arrays — people page should populate after the import job completes
- [ ] Verify duplicate photos (already in library) also get their people tags written via the dedup path

🤖 Generated with [Claude Code](https://claude.com/claude-code)