### PR TITLE
feat: add VIDEO badge to video thumbnails

### DIFF
--- a/frontend/src/components/MediaCard.tsx
+++ b/frontend/src/components/MediaCard.tsx
@@ -102,6 +102,11 @@ export function MediaCard({ asset, width, height, token, onClick }: MediaCardPro
           ▶ LIVE
         </span>
       )}
+      {!asset.is_live_photo && asset.mime_type.startsWith("video/") && (
+        <span className="absolute bottom-1 left-1 rounded-full bg-blue-600/60 px-1 text-xs text-white">
+          ▶ VIDEO
+        </span>
+      )}
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a blue `▶ VIDEO` badge to non-live-photo video thumbnails in the grid
- Mirrors the existing `▶ LIVE` badge pattern in `MediaCard.tsx`
- Mutually exclusive with the LIVE badge (live photos keep their existing indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)